### PR TITLE
Rich text support

### DIFF
--- a/src/app/[author]/page.tsx
+++ b/src/app/[author]/page.tsx
@@ -10,7 +10,7 @@ import { filterPosts } from "../../utils/posts";
 import { BackArrowIcon } from "../icons/back-arrow";
 import Link from "next/link";
 import type { AppBskyActorDefs, AppBskyFeedDefs } from "@atproto/api";
-
+import { ProfileDescription } from "~/components/ProfileDescription";
 function ProfileHeader({ profile }: { profile: AppBskyActorDefs.ProfileViewDetailed }) {
   return (
     <div>
@@ -37,7 +37,11 @@ function ProfileHeader({ profile }: { profile: AppBskyActorDefs.ProfileViewDetai
             <p className="text-text-tertiary">@{profile.handle}</p>
           </div>
         </div>
-        {profile.description && <p className="mt-4 text-text-secondary">{profile.description}</p>}
+        {profile.description && (
+          <p className="mt-4 text-text-secondary">
+            <ProfileDescription description={profile.description} />
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/app/hooks/index.ts
+++ b/src/app/hooks/index.ts
@@ -4,5 +4,6 @@ export { useInfiniteScroll } from "./use-infinite-scroll";
 export { useCurrentProfile, useProfile } from "./use-profile";
 export { useThread } from "./use-thread";
 export { useNotifications } from "./use-notifications";
+export { useRichText } from "./use-rich-text";
 
 export type { NotificationType } from "./use-notifications";

--- a/src/app/hooks/use-rich-text.ts
+++ b/src/app/hooks/use-rich-text.ts
@@ -1,0 +1,23 @@
+import { RichText as RichTextAPI } from "@atproto/api";
+import { useState, useEffect } from "react";
+import { agent } from "~/lib/api";
+
+export function useRichText(text: string) {
+  const [richText, setRichText] = useState(() => new RichTextAPI({ text }));
+  const [isResolving, setIsResolving] = useState(true);
+
+  useEffect(() => {
+    const rt = new RichTextAPI({ text });
+    rt.detectFacets(agent)
+      .then(() => {
+        setRichText(rt);
+        setIsResolving(false);
+      })
+      .catch((error) => {
+        console.error("Failed to detect facets:", error);
+        setIsResolving(false);
+      });
+  }, [text]);
+
+  return [richText, isResolving] as const;
+}

--- a/src/components/PostItem.tsx
+++ b/src/components/PostItem.tsx
@@ -2,15 +2,12 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import type {
-  AppBskyFeedDefs,
-  AppBskyFeedPost,
-  AppBskyEmbedImages,
-} from "@atproto/api";
+import type { AppBskyFeedDefs, AppBskyFeedPost, AppBskyEmbedImages } from "@atproto/api";
 import { formatDistanceToNow, format } from "date-fns";
 import Link from "next/link";
 import { agent } from "../lib/api";
 import { useState, useCallback } from "react";
+import { RichText } from "./RichText";
 
 interface PostItemProps {
   post: AppBskyFeedDefs.PostView;
@@ -169,7 +166,9 @@ export function PostItem({
               <div className="text-text-tertiary">@{author.handle}</div>
             </div>
           </div>
-          <div className="mb-3 text-xl text-text-secondary">{record.text}</div>
+          <div className="mb-3 text-xl text-text-secondary">
+            <RichText text={record.text} facets={record.facets} />
+          </div>
           {post.embed?.$type === "app.bsky.embed.images#view" && (
             <div className="grid gap-2 media-container">
               {(post.embed as AppBskyEmbedImages.View).images.map(
@@ -273,7 +272,7 @@ export function PostItem({
               )}
             </div>
             <div className="text-text-secondary">
-              {record.text}
+              <RichText text={record.text} facets={record.facets} />
               {post.embed?.$type === "app.bsky.embed.images#view" && (
                 <div className="grid gap-2 mt-2 media-container">
                   {(post.embed as AppBskyEmbedImages.View).images.map(

--- a/src/components/ProfileDescription.tsx
+++ b/src/components/ProfileDescription.tsx
@@ -1,0 +1,16 @@
+import { useRichText } from "../app/hooks/use-rich-text";
+import { RichText } from "./RichText";
+
+interface ProfileDescriptionProps {
+  description: string;
+}
+
+export function ProfileDescription({ description }: ProfileDescriptionProps) {
+  const [richText, isResolving] = useRichText(description);
+
+  if (isResolving) {
+    return <span>{description}</span>;
+  }
+
+  return <RichText text={richText.text} facets={richText.facets} />;
+}

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import Link from "next/link";
+// It looks like we have no choice but to import the whole API to get the RichText functionality
+// This is not ideal from a perf perspective (708.5k import), but the alternative is to write our own parser, which, no.
+import { RichText as RichTextAPI, AppBskyRichtextFacet } from "@atproto/api";
+
+interface RichTextProps {
+  text: string;
+  facets?: AppBskyRichtextFacet.Main[];
+  disableLinks?: boolean;
+}
+
+export function RichText({ text, facets, disableLinks = false }: RichTextProps) {
+  const richText = React.useMemo(() => new RichTextAPI({ text, facets }), [text, facets]);
+
+  const elements = [];
+  let key = 0;
+
+  for (const segment of richText.segments()) {
+    const link = segment.link;
+    const mention = segment.mention;
+    const tag = segment.tag;
+
+    if (link && !disableLinks && AppBskyRichtextFacet.validateLink(link).success) {
+      elements.push(
+        <a
+          key={key}
+          href={link.uri}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-text-primary hover:underline"
+        >
+          {segment.text}
+        </a>
+      );
+    } else if (mention && !disableLinks && AppBskyRichtextFacet.validateMention(mention).success) {
+      elements.push(
+        <Link
+          key={key}
+          href={`/profile/${mention.did}`}
+          className="text-text-primary hover:underline"
+        >
+          {segment.text}
+        </Link>
+      );
+    } else if (tag && !disableLinks && AppBskyRichtextFacet.validateTag(tag).success) {
+      elements.push(
+        <Link key={key} href={`/search?q=${encodeURIComponent(tag.tag)}`}>
+          {segment.text}
+        </Link>
+      );
+    } else {
+      elements.push(segment.text);
+    }
+    key++;
+  }
+
+  return <span className="whitespace-pre-wrap">{elements}</span>;
+}


### PR DESCRIPTION
# Summary

Adds rich text support for posts, replies, and profiles

This change is needed to properly display interactive elements in posts, replies and profiles, as the current plaintext implementation doesn't support clickable links, mentions, or hashtags.

Adds support for rich text parsing and rendering throughout the app, including:
- New `RichText` component to handle links, mentions, and hashtags
- `useRichText` hook for facet detection with agent integration
- Rich text rendering in post content and profile descriptions
- Proper whitespace and line break preservation

Uses @atproto/api to ensure compatibility with AT Protocol lexicons and facet validation. This enables clickable links, user mentions, and hashtags while maintaining consistent text formatting across the app.