### PR TITLE
Fix mentions routing

### DIFF
--- a/src/app/[author]/page.tsx
+++ b/src/app/[author]/page.tsx
@@ -11,6 +11,7 @@ import { BackArrowIcon } from "../icons/back-arrow";
 import Link from "next/link";
 import type { AppBskyActorDefs, AppBskyFeedDefs } from "@atproto/api";
 import { ProfileDescription } from "~/components/ProfileDescription";
+
 function ProfileHeader({ profile }: { profile: AppBskyActorDefs.ProfileViewDetailed }) {
   return (
     <div>
@@ -112,8 +113,10 @@ export default function ProfilePage() {
   const params = useParams();
   const { isAuthenticated } = useAuth();
   const [selectedFeed, setSelectedFeed] = useState<"posts" | "replies" | "media">("posts");
+  // Need to decode the identifier for DIDs
+  const identifier = decodeURIComponent(params.author as string);
 
-  const { data: profile } = useProfile(params.author as string, isAuthenticated);
+  const { data: profile } = useProfile(identifier, isAuthenticated);
 
   const {
     data: feedData,
@@ -121,7 +124,7 @@ export default function ProfilePage() {
     hasNextPage,
     isFetchingNextPage,
     isPending: isFeedPending,
-  } = useProfileFeed(params.author as string, selectedFeed, isAuthenticated);
+  } = useProfileFeed(identifier, selectedFeed, isAuthenticated);
 
   const { lastElementRef } = useInfiniteScroll({
     fetchNextPage,

--- a/src/app/hooks/use-feeds.ts
+++ b/src/app/hooks/use-feeds.ts
@@ -49,7 +49,7 @@ export function useHomeFeed(
 }
 
 export function useProfileFeed(
-  handle: string | null,
+  identifier: string | null,
   feedType: "posts" | "replies" | "media",
   isAuthenticated: boolean
 ) {
@@ -60,17 +60,12 @@ export function useProfileFeed(
     (string | null)[],
     string | undefined
   >({
-    queryKey: ["profile-feed", handle, feedType] as (string | null)[],
+    queryKey: ["profile-feed", identifier, feedType] as (string | null)[],
     queryFn: async ({ pageParam }) => {
-      if (!handle || !isAuthenticated) return { feed: [], cursor: undefined };
-
-      const { data: resolveData } =
-        await agent.com.atproto.identity.resolveHandle({
-          handle,
-        });
+      if (!identifier || !isAuthenticated) return { feed: [], cursor: undefined };
 
       const feedData = await agent.getAuthorFeed({
-        actor: resolveData.did,
+        actor: identifier,
         limit: queryConfig.limit,
         cursor: pageParam,
       });
@@ -79,7 +74,7 @@ export function useProfileFeed(
     },
     initialPageParam: undefined,
     getNextPageParam: (lastPage) => lastPage.cursor,
-    enabled: !!handle && isAuthenticated,
+    enabled: !!identifier && isAuthenticated,
     ...queryConfig.profileFeed,
   });
 }

--- a/src/app/hooks/use-profile.ts
+++ b/src/app/hooks/use-profile.ts
@@ -20,18 +20,18 @@ export function useCurrentProfile(isAuthenticated: boolean) {
 }
 
 // For viewing other users' profiles
-export function useProfile(handle: string | null, isAuthenticated: boolean) {
+export function useProfile(identifier: string | null, isAuthenticated: boolean) {
   return useQuery<AppBskyActorDefs.ProfileViewDetailed>({
-    queryKey: ["profile", handle],
+    queryKey: ["profile", identifier],
     queryFn: async () => {
-      if (!handle) throw new Error("Handle is required");
-      const { data: resolveData } = await agent.com.atproto.identity.resolveHandle({
-        handle,
+      if (!identifier) throw new Error("Identifier is required");
+
+      const { data } = await agent.getProfile({
+        actor: identifier,
       });
-      const profileData = await agent.getProfile({ actor: resolveData.did });
-      return profileData.data;
+      return data;
     },
-    enabled: !!handle && isAuthenticated,
+    enabled: !!identifier && isAuthenticated,
     ...queryConfig.profile,
   });
 }

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -29,23 +29,30 @@ export function RichText({ text, facets, disableLinks = false }: RichTextProps) 
           target="_blank"
           rel="noopener noreferrer"
           className="text-text-primary hover:underline"
+          onClick={(e) => e.stopPropagation()}
         >
           {segment.text}
         </a>
       );
     } else if (mention && !disableLinks && AppBskyRichtextFacet.validateMention(mention).success) {
+      console.log("mention", mention);
       elements.push(
         <Link
           key={key}
-          href={`/profile/${mention.did}`}
+          href={`/${mention.did}`}
           className="text-text-primary hover:underline"
+          onClick={(e) => e.stopPropagation()}
         >
           {segment.text}
         </Link>
       );
     } else if (tag && !disableLinks && AppBskyRichtextFacet.validateTag(tag).success) {
       elements.push(
-        <Link key={key} href={`/search?q=${encodeURIComponent(tag.tag)}`}>
+        <Link
+          key={key}
+          href={`/search?q=${encodeURIComponent(tag.tag)}`}
+          onClick={(e) => e.stopPropagation()}
+        >
           {segment.text}
         </Link>
       );

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -36,7 +36,6 @@ export function RichText({ text, facets, disableLinks = false }: RichTextProps) 
         </a>
       );
     } else if (mention && !disableLinks && AppBskyRichtextFacet.validateMention(mention).success) {
-      console.log("mention", mention);
       elements.push(
         <Link
           key={key}

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -46,16 +46,17 @@ export function RichText({ text, facets, disableLinks = false }: RichTextProps) 
           {segment.text}
         </Link>
       );
-    } else if (tag && !disableLinks && AppBskyRichtextFacet.validateTag(tag).success) {
-      elements.push(
-        <Link
-          key={key}
-          href={`/search?q=${encodeURIComponent(tag.tag)}`}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {segment.text}
-        </Link>
-      );
+      // TODO: Add search route for hashtags, then uncomment this
+      // } else if (tag && !disableLinks && AppBskyRichtextFacet.validateTag(tag).success) {
+      //   elements.push(
+      //     <Link
+      //       key={key}
+      //       href={`/search?q=${encodeURIComponent(tag.tag)}`}
+      //       onClick={(e) => e.stopPropagation()}
+      //     >
+      //       {segment.text}
+      //     </Link>
+      //   );
     } else {
       elements.push(segment.text);
     }

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -19,7 +19,8 @@ export function RichText({ text, facets, disableLinks = false }: RichTextProps) 
   for (const segment of richText.segments()) {
     const link = segment.link;
     const mention = segment.mention;
-    const tag = segment.tag;
+    // TODO: Add search route for hashtags, then uncomment this
+    // const tag = segment.tag;
 
     if (link && !disableLinks && AppBskyRichtextFacet.validateLink(link).success) {
       elements.push(


### PR DESCRIPTION
# Summary

#12 revealed a problem in our previous implementation of profile routes. We were only handling a user's `handle` and not their `DID`. In the `RichText` component, I was linking incorrectly to `/profile/:did` and our `useProfile` fetch was looking for a handle and failing to resolve it (to say nothing of the `/profile` segment, which doesn't even exist in our route structure...whoops). The fix was to make `useProfile` support DIDs as well as handles (which the Bluesky API actually gives us out of the box and in fact makes our code easier) and to remove the `/profile` path segment. 

TLDR; clicking on a mention should now not result in a 400 (bad request).